### PR TITLE
Correct a typo in the sidenav.

### DIFF
--- a/src/app/layout/sidenav/sidenav.component.html
+++ b/src/app/layout/sidenav/sidenav.component.html
@@ -21,7 +21,7 @@
     <li>
       <a routerLink="/advance" routerLinkActive="active">
         <i class="material-icons mx-4 align-middle">build</i>
-        <span>Advance Features</span>
+        <span>Advanced Features</span>
       </a>
     </li>
     <li>


### PR DESCRIPTION
In the sidenav there was "Advance Features" and at the feature title there was "Advanced Features" which I think is correct form, so I changed it to match.